### PR TITLE
Added necessary path to example code

### DIFF
--- a/firmware/examples/matrixpaneldemo.ino
+++ b/firmware/examples/matrixpaneldemo.ino
@@ -1,5 +1,5 @@
 // This #include statement was automatically added by the Spark IDE.
-#include "LedControl-MAX7219-MAX7221.h"
+#include "LedControl-MAX7219-MAX7221/LedControl-MAX7219-MAX7221.h"
 
 LedControl *led;
 int phase = 0;


### PR DESCRIPTION
Hi, thanks for pulling this together! I just discovered an error that I'd seen in my own library dev. When code is including a library rather than having the files wrapped up with it in the editor then the library's files are actually in a subdirectory named identically to the library. Check my fix if that's a bit murky.

Example code compiles now!
