### PR TITLE
Fixed path for Build compatibility

### DIFF
--- a/firmware/examples/matrixpaneldemo.ino
+++ b/firmware/examples/matrixpaneldemo.ino
@@ -1,5 +1,5 @@
 // This #include statement was automatically added by the Spark IDE.
-#include "LedControl-MAX7219-MAX7221.h"
+#include "LedControl-MAX7219-MAX7221/LedControl-MAX7219-MAX7221.h"
 
 LedControl *led;
 int phase = 0;


### PR DESCRIPTION
Hi, Richard from Particle here. Was going through the top 100 libraries (congrats!) and noticed that there was an include path problem for this example and wrote a little fix. Please merge and reimport the library into Build.

Thanks!
